### PR TITLE
Mountable Filesystem

### DIFF
--- a/engine/fs/fstest/fstest.go
+++ b/engine/fs/fstest/fstest.go
@@ -17,7 +17,11 @@ func must(t *testing.T, err error) {
 
 func ReadFS(t *testing.T, fsys fs.FS) map[string]string {
 	fsmap := map[string]string{}
-	must(t, fs.WalkDir(fsys, "", func(path string, d fs.DirEntry, err error) error {
+	must(t, fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if d.IsDir() {
 			fsmap[path+"/"] = ""
 			return nil

--- a/engine/fs/livedir.go
+++ b/engine/fs/livedir.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"embed"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,5 +18,5 @@ func LiveDir(assets embed.FS) FS {
 	if os.IsNotExist(err) {
 		return assets
 	}
-	return watchfs.New(os.DirFS(filepath.Dir(filename)))
+	return watchfs.New(os.DirFS(filepath.Dir(filename)).(fs.StatFS))
 }

--- a/engine/fs/mountablefs/mountablefs.go
+++ b/engine/fs/mountablefs/mountablefs.go
@@ -2,7 +2,6 @@ package mountablefs
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
@@ -102,7 +101,7 @@ func (host *FS) Chmod(name string, mode fs.FileMode) error  {
 		Chmod(name string, mode fs.FileMode) error
 	})
 	if !ok {
-		return fmt.Errorf("chmod: %w", errors.ErrUnsupported)
+		return &fs.PathError{Op: "chmod", Path: name, Err: errors.ErrUnsupported}
 	}
 	return chmodableFS.Chmod(trimMountPoint(name, prefix), mode)
 }
@@ -123,7 +122,7 @@ func (host *FS) Chown(name string, uid, gid int) error  {
 		Chown(name string, uid, gid int) error
 	})
 	if !ok {
-		return fmt.Errorf("chown: %w", errors.ErrUnsupported)
+		return &fs.PathError{Op: "chown", Path: name, Err: errors.ErrUnsupported}
 	}
 	return chownableFS.Chown(trimMountPoint(name, prefix), uid, gid)
 }
@@ -144,7 +143,7 @@ func (host *FS) Chtimes(name string, atime time.Time, mtime time.Time) error  {
 		Chtimes(name string, atime time.Time, mtime time.Time) error
 	})
 	if !ok {
-		return fmt.Errorf("chtimes: %w", errors.ErrUnsupported)
+		return &fs.PathError{Op: "chtimes", Path: name, Err: errors.ErrUnsupported}
 	}
 	return chtimesableFS.Chtimes(trimMountPoint(name, prefix), atime, mtime)
 }
@@ -166,7 +165,7 @@ func (host *FS) Create(name string) (fs.File, error)  {
 		Create(name string) (fs.File, error)
 	})
 	if !ok {
-		return nil, fmt.Errorf("create: %w", errors.ErrUnsupported)
+		return nil, &fs.PathError{Op: "create", Path: name, Err: errors.ErrUnsupported}
 	}
 	return createableFS.Create(trimMountPoint(name, prefix))
 }
@@ -187,7 +186,7 @@ func (host *FS) Mkdir(name string, perm fs.FileMode) error  {
 		Mkdir(name string, perm fs.FileMode) error
 	})
 	if !ok {
-		return fmt.Errorf("mkdir: %w", errors.ErrUnsupported)
+		return &fs.PathError{Op: "mkdir", Path: name, Err: errors.ErrUnsupported}
 	}
 	return mkdirableFS.Mkdir(trimMountPoint(name, prefix), perm)
 }
@@ -208,7 +207,7 @@ func (host *FS) MkdirAll(path string, perm fs.FileMode) error  {
 		MkdirAll(path string, perm fs.FileMode) error
 	})
 	if !ok {
-		return fmt.Errorf("mkdir_all: %w", errors.ErrUnsupported)
+		return &fs.PathError{Op: "mkdir_all", Path: path, Err: errors.ErrUnsupported}
 	}
 	return mkdirableFS.MkdirAll(trimMountPoint(path, prefix), perm)
 }
@@ -306,7 +305,7 @@ func (host *FS) Rename(oldname, newname string) error  {
 		Rename(oldname, newname string) error
 	})
 	if !ok {
-		return fmt.Errorf("rename: %w", errors.ErrUnsupported)
+		return &fs.PathError{Op: "rename", Path: oldname+" -> "+newname, Err: errors.ErrUnsupported}
 	}
 	return renameableFS.Rename(trimMountPoint(oldname, prefix), trimMountPoint(newname, prefix))
 }

--- a/engine/fs/mountablefs/mountablefs.go
+++ b/engine/fs/mountablefs/mountablefs.go
@@ -1,0 +1,148 @@
+package mountablefs
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"tractor.dev/toolkit-go/engine/fs/fsutil"
+)
+
+type mountedFSDir struct {
+	fsys fs.FS
+	mountPoint string
+}
+
+type FS struct {
+	fs.FS
+	mounts []mountedFSDir
+}
+
+func New(fsys fs.FS) *FS {
+	return &FS{FS: fsys, mounts: make([]mountedFSDir, 0, 1)}
+}
+
+func (host *FS) Mount(fsys fs.FS, dir_path string) error {
+	dir_path = filepath.Clean(dir_path)
+
+	fi, err := fs.Stat(host, dir_path)
+	if err != nil {
+		return err
+	}
+
+	if !fi.IsDir() {
+		return &fs.PathError{Op: "mount", Path: dir_path, Err: fs.ErrInvalid}
+	}
+
+	host.mounts = append(host.mounts, mountedFSDir{fsys: fsys, mountPoint: dir_path})
+	return nil
+}
+
+func (host *FS) Unmount(path string) error {
+	path = filepath.Clean(path)
+	for i, m := range host.mounts {
+		if path == m.mountPoint {
+			host.mounts = remove(host.mounts, i)
+			return nil
+		}
+	}
+
+	return &fs.PathError{Op: "unmount", Path: path, Err: fs.ErrInvalid}
+}
+
+func remove(s []mountedFSDir, i int) []mountedFSDir {
+    s[i] = s[len(s)-1]
+    return s[:len(s)-1]
+}
+
+func (host *FS) isPathInMount(path string) (bool, *mountedFSDir) {
+	for i, m := range host.mounts {
+		if strings.HasPrefix(path, m.mountPoint) {
+			return true, &host.mounts[i]
+		}
+	}
+	return false, nil
+}
+
+func trimMountPoint(path string, mntPoint string) string {
+	result := strings.TrimPrefix(path, mntPoint)
+	return filepath.Clean(strings.TrimPrefix(result, "/"))
+}
+
+// TODO:
+// func (host *FS) Chmod(name string, mode fs.FileMode) error  {}
+// func (host *FS) Chown(name string, uid, gid int) error  {}
+// func (host *FS) Chtimes(name string, atime time.Time, mtime time.Time) error  {}
+// func (host *FS) Create(name string) (fs.File, error)  {}
+// func (host *FS) Mkdir(name string, perm fs.FileMode) error  {}
+// func (host *FS) MkdirAll(path string, perm fs.FileMode) error  {}
+
+func (host *FS) Open(name string) (fs.File, error)  {
+	if !fs.ValidPath(name) { // TODO: may be redundant
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	if found, mount := host.isPathInMount(name); found {
+		mntPath := trimMountPoint(name, mount.mountPoint)
+		fmt.Println("Open name:", name, "\tprefix:", mount.mountPoint, "\tmntPath:", mntPath)
+		return mount.fsys.Open(mntPath)
+	}
+
+	return host.FS.Open(name)
+}
+
+func (host *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error)  {
+	if found, mount := host.isPathInMount(name); found {
+		return fsutil.OpenFile(mount.fsys, trimMountPoint(name, mount.mountPoint), flag, perm)
+	} else {
+		return fsutil.OpenFile(host.FS, name, flag, perm)
+	}
+}
+
+func (host *FS) Remove(name string) error  {
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(name); found {
+		fsys = mount.fsys
+		// TODO: maybe error if trying to remove mountPoint?
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.FS
+	}
+
+	removableFS, ok := fsys.(interface {
+		Remove(name string) error
+	})
+	if !ok {
+		return fmt.Errorf("remove: %w", errors.ErrUnsupported)
+	}
+	return removableFS.Remove(trimMountPoint(name, prefix))
+}
+
+func (host *FS) RemoveAll(path string) error  {
+	var fsys fs.FS
+	prefix := ""
+
+	if found, mount := host.isPathInMount(path); found {
+		fsys = mount.fsys
+		// TODO: maybe error if trying to remove mountPoint?
+		prefix = mount.mountPoint
+	} else {
+		fsys = host.FS
+	}
+
+	removableFS, ok := fsys.(interface {
+		RemoveAll(path string) error
+	})
+	if !ok {
+		// TODO: default implementation which depends on fsys supporting Remove
+		return fmt.Errorf("remove_all: %w", errors.ErrUnsupported)
+	}
+	return removableFS.RemoveAll(trimMountPoint(path, prefix))
+}
+
+// func (host *FS) Rename(oldname, newname string) error  {}
+// func (host *FS) Stat(name string) (fs.FileInfo, error)  {}

--- a/engine/fs/mountablefs/mountablefs.go
+++ b/engine/fs/mountablefs/mountablefs.go
@@ -382,21 +382,3 @@ func (host *FS) Rename(oldname, newname string) error {
 	}
 	return renameableFS.Rename(trimMountPoint(oldname, prefix), trimMountPoint(newname, prefix))
 }
-
-// Stat is unecessary since fs.Stat calls Open, which will return a
-// File from the correct filesystem anyway. Leaving this here in case
-// it's useful in the future.
-// func (host *FS) Stat(name string) (fs.FileInfo, error)  {
-//  name = cleanPath(name)
-// 	var fsys fs.FS
-// 	prefix := ""
-
-// 	if found, mount := host.isPathInMount(name); found {
-// 		fsys = mount.fsys
-// 		prefix = mount.mountPoint
-// 	} else {
-// 		fsys = host.FS
-// 	}
-
-// 	return fs.Stat(fsys, trimMountPoint(name, prefix))
-// }

--- a/engine/fs/mountablefs/mountablefs.go
+++ b/engine/fs/mountablefs/mountablefs.go
@@ -13,7 +13,7 @@ import (
 )
 
 type mountedFSDir struct {
-	fsys fs.FS
+	fsys       fs.FS
 	mountPoint string
 }
 
@@ -58,8 +58,8 @@ func (host *FS) Unmount(path string) error {
 }
 
 func remove(s []mountedFSDir, i int) []mountedFSDir {
-    s[i] = s[len(s)-1]
-    return s[:len(s)-1]
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
 }
 
 func (host *FS) isPathInMount(path string) (bool, *mountedFSDir) {
@@ -78,7 +78,7 @@ func cleanPath(p string) string {
 func trimMountPoint(path string, mntPoint string) string {
 	result := strings.TrimPrefix(path, mntPoint)
 	result = strings.TrimPrefix(result, string(filepath.Separator))
-	
+
 	if result == "" {
 		return "."
 	} else {
@@ -86,7 +86,7 @@ func trimMountPoint(path string, mntPoint string) string {
 	}
 }
 
-func (host *FS) Chmod(name string, mode fs.FileMode) error  {
+func (host *FS) Chmod(name string, mode fs.FileMode) error {
 	name = cleanPath(name)
 	var fsys fs.FS
 	prefix := ""
@@ -107,7 +107,7 @@ func (host *FS) Chmod(name string, mode fs.FileMode) error  {
 	return chmodableFS.Chmod(trimMountPoint(name, prefix), mode)
 }
 
-func (host *FS) Chown(name string, uid, gid int) error  {
+func (host *FS) Chown(name string, uid, gid int) error {
 	name = cleanPath(name)
 	var fsys fs.FS
 	prefix := ""
@@ -128,7 +128,7 @@ func (host *FS) Chown(name string, uid, gid int) error  {
 	return chownableFS.Chown(trimMountPoint(name, prefix), uid, gid)
 }
 
-func (host *FS) Chtimes(name string, atime time.Time, mtime time.Time) error  {
+func (host *FS) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	name = cleanPath(name)
 	var fsys fs.FS
 	prefix := ""
@@ -149,8 +149,7 @@ func (host *FS) Chtimes(name string, atime time.Time, mtime time.Time) error  {
 	return chtimesableFS.Chtimes(trimMountPoint(name, prefix), atime, mtime)
 }
 
-
-func (host *FS) Create(name string) (fs.File, error)  {
+func (host *FS) Create(name string) (fs.File, error) {
 	name = cleanPath(name)
 	var fsys fs.FS
 	prefix := ""
@@ -171,7 +170,7 @@ func (host *FS) Create(name string) (fs.File, error)  {
 	return createableFS.Create(trimMountPoint(name, prefix))
 }
 
-func (host *FS) Mkdir(name string, perm fs.FileMode) error  {
+func (host *FS) Mkdir(name string, perm fs.FileMode) error {
 	name = cleanPath(name)
 	var fsys fs.FS
 	prefix := ""
@@ -192,7 +191,7 @@ func (host *FS) Mkdir(name string, perm fs.FileMode) error  {
 	return mkdirableFS.Mkdir(trimMountPoint(name, prefix), perm)
 }
 
-func (host *FS) MkdirAll(path string, perm fs.FileMode) error  {
+func (host *FS) MkdirAll(path string, perm fs.FileMode) error {
 	path = cleanPath(path)
 	var fsys fs.FS
 	prefix := ""
@@ -213,7 +212,7 @@ func (host *FS) MkdirAll(path string, perm fs.FileMode) error  {
 	return mkdirableFS.MkdirAll(trimMountPoint(path, prefix), perm)
 }
 
-func (host *FS) Open(name string) (fs.File, error)  {
+func (host *FS) Open(name string) (fs.File, error) {
 	name = cleanPath(name)
 	if found, mount := host.isPathInMount(name); found {
 		return mount.fsys.Open(trimMountPoint(name, mount.mountPoint))
@@ -222,7 +221,7 @@ func (host *FS) Open(name string) (fs.File, error)  {
 	return host.FS.Open(name)
 }
 
-func (host *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error)  {
+func (host *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
 	if found, mount := host.isPathInMount(name); found {
 		return fsutil.OpenFile(mount.fsys, trimMountPoint(name, mount.mountPoint), flag, perm)
 	} else {
@@ -235,7 +234,7 @@ type removableFS interface {
 	Remove(name string) error
 }
 
-func (host *FS) Remove(name string) error  {
+func (host *FS) Remove(name string) error {
 	name = cleanPath(name)
 	var fsys fs.FS
 	prefix := ""
@@ -258,7 +257,7 @@ func (host *FS) Remove(name string) error  {
 	}
 }
 
-func (host *FS) RemoveAll(path string) error  {
+func (host *FS) RemoveAll(path string) error {
 	path = cleanPath(path)
 	var fsys fs.FS
 	prefix := ""
@@ -299,10 +298,8 @@ func (host *FS) RemoveAll(path string) error  {
 	return rmAllFS.RemoveAll(trimMountPoint(path, prefix))
 }
 
-
-
-// RemoveAll removes path and any children it contains. It removes everything 
-// it can but returns the first error it encounters. If the path does not exist, 
+// RemoveAll removes path and any children it contains. It removes everything
+// it can but returns the first error it encounters. If the path does not exist,
 // RemoveAll returns nil (no error). If there is an error, it will be of type *PathError.
 // Additionally, this function errors if attempting to remove a mountpoint.
 func removeAll(fsys removableFS, path string, mntPoints []string) error {
@@ -330,7 +327,7 @@ func rm_r(fsys removableFS, path string, mntPoints []string) error {
 		if entries, err := fs.ReadDir(fsys, path); err == nil {
 			for _, entry := range entries {
 				entryPath := filepath.Join(path, entry.Name())
-				
+
 				if err := rm_r(fsys, entryPath, mntPoints); err != nil {
 					return err
 				}
@@ -344,11 +341,10 @@ func rm_r(fsys removableFS, path string, mntPoints []string) error {
 		}
 	}
 
-
 	return fsys.Remove(path)
 }
 
-func (host *FS) Rename(oldname, newname string) error  {
+func (host *FS) Rename(oldname, newname string) error {
 	oldname = cleanPath(oldname)
 	newname = cleanPath(newname)
 	var fsys fs.FS
@@ -358,18 +354,21 @@ func (host *FS) Rename(oldname, newname string) error  {
 	if found, oldMount := host.isPathInMount(oldname); found {
 		if found, newMount := host.isPathInMount(newname); found {
 			if oldMount != newMount {
-				return &fs.PathError{Op: "rename", Path: oldname+" -> "+newname, Err: syscall.EXDEV}		
+				return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EXDEV}
 			}
 
-			// TODO: error if trying to rename mountPoint?
+			if oldname == oldMount.mountPoint || newname == newMount.mountPoint {
+				return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EBUSY}
+			}
+
 			fsys = newMount.fsys
 			prefix = newMount.mountPoint
 		} else {
-			return &fs.PathError{Op: "rename", Path: oldname+" -> "+newname, Err: syscall.EXDEV}		
-		}	
+			return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EXDEV}
+		}
 	} else {
 		if found, _ := host.isPathInMount(newname); found {
-			return &fs.PathError{Op: "rename", Path: oldname+" -> "+newname, Err: syscall.EXDEV}		
+			return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: syscall.EXDEV}
 		}
 
 		fsys = host.FS
@@ -379,13 +378,13 @@ func (host *FS) Rename(oldname, newname string) error  {
 		Rename(oldname, newname string) error
 	})
 	if !ok {
-		return &fs.PathError{Op: "rename", Path: oldname+" -> "+newname, Err: errors.ErrUnsupported}
+		return &fs.PathError{Op: "rename", Path: oldname + " -> " + newname, Err: errors.ErrUnsupported}
 	}
 	return renameableFS.Rename(trimMountPoint(oldname, prefix), trimMountPoint(newname, prefix))
 }
 
 // Stat is unecessary since fs.Stat calls Open, which will return a
-// File from the correct filesystem anyway. Leaving this here in case 
+// File from the correct filesystem anyway. Leaving this here in case
 // it's useful in the future.
 // func (host *FS) Stat(name string) (fs.FileInfo, error)  {
 //  name = cleanPath(name)

--- a/engine/fs/mountablefs/mountablefs_test.go
+++ b/engine/fs/mountablefs/mountablefs_test.go
@@ -8,7 +8,7 @@ import (
 	"tractor.dev/toolkit-go/engine/fs/memfs"
 )
 
-func TestMountableFS(t *testing.T) {
+func TestMountUnmount(t *testing.T) {
     host := memfs.New()
     mnt := memfs.New()
 
@@ -54,3 +54,102 @@ func TestMountableFS(t *testing.T) {
         t.Fatalf("unexpected file %s: expected error %v", "mount/rickroll.mpv", fs.ErrNotExist)
     }
 }
+
+func TestRemove(t *testing.T) {
+    host := memfs.New()
+    mnt := memfs.New()
+
+    fstest.WriteFS(t, host, map[string]string{
+        "A/B": "host",
+        "C/D/blah": "host",
+    })
+
+    fstest.WriteFS(t, mnt, map[string]string{
+        "E/F": "mounted",
+        "G/H": "mounted",
+    })
+
+    fsys := New(host)
+    if err := fsys.Mount(mnt, "C/D"); err != nil {
+        t.Fatal(err)
+    }
+
+    fstest.CheckFS(t, fsys, map[string]string{
+        "A/B": "host",
+        "C/D/E/F": "mounted",
+        "C/D/G/H": "mounted",
+    })
+
+    if err := fsys.Remove("A/B"); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := fsys.Remove("C/D/E/F"); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := fsys.RemoveAll("C/D/G"); err != nil {
+        t.Fatal(err)
+    }
+
+    fstest.CheckFS(t, fsys, map[string]string{
+        // dirs are empty
+        "A/": "",
+        "C/D/E/": "",
+    })
+
+    if err := fsys.Remove("A/B"); err == nil {
+        t.Fatalf("expected attempt to Remove a non-existant file to fail")
+    }
+
+    if err := fsys.Remove("C/D/G"); err == nil {
+        t.Fatalf("expected attempt to Remove a non-existant file to fail")
+    }
+
+    if err := fsys.Unmount("C/D"); err != nil {
+        t.Fatal(err)
+    }
+}
+
+func TestRename(t *testing.T) {
+    host := memfs.New()
+    mnt := memfs.New()
+
+    fstest.WriteFS(t, host, map[string]string{
+        "all":             "host",
+        "mount/host-data": "host",
+    })
+
+    fstest.WriteFS(t, mnt, map[string]string{
+        "all2":         "mounted",
+        "rickroll.mpv": "mounted",
+    })
+
+    fsys := New(host)
+    if err := fsys.Mount(mnt, "mount"); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := fsys.Rename("all", "none"); err != nil {
+        t.Fatal(err)
+    }
+    
+    if err := fsys.Rename("mount/all2", "mount/none2"); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := fsys.Rename("mount/rickroll.mpv", "rickroll.mpv"); err == nil {
+        t.Fatalf("expected error when attempting to rename across filesystems")
+    }
+
+    fstest.CheckFS(t, fsys, map[string]string{
+        "none": "host",
+        "mount/none2": "mounted",
+        "mount/rickroll.mpv": "mounted",
+    })
+
+    if err := fsys.Unmount("mount"); err != nil {
+        t.Fatal(err)
+    }
+}
+

--- a/engine/fs/mountablefs/mountablefs_test.go
+++ b/engine/fs/mountablefs/mountablefs_test.go
@@ -1,0 +1,56 @@
+package mountablefs
+
+import (
+	"io/fs"
+	"testing"
+
+	"tractor.dev/toolkit-go/engine/fs/fstest"
+	"tractor.dev/toolkit-go/engine/fs/memfs"
+)
+
+func TestMountableFS(t *testing.T) {
+    host := memfs.New()
+    mnt := memfs.New()
+
+    fstest.WriteFS(t, host, map[string]string{
+        "all":             "host",
+        "mount/host-data": "host",
+    })
+
+    fstest.WriteFS(t, mnt, map[string]string{
+        "all2":         "mounted",
+        "rickroll.mpv": "mounted",
+    })
+
+    fsys := New(host)
+    if err := fsys.Mount(mnt, "mount"); err != nil {
+        t.Fatal(err)
+    }
+
+    fstest.CheckFS(t, fsys, map[string]string{
+        "all": "host",
+        "mount/all2": "mounted",
+        "mount/rickroll.mpv": "mounted",
+    })
+
+    if _, err := fsys.Open("mount/host-data"); err == nil {
+        t.Fatalf("expected file %s to be masked by mount: got nil, expected %v", "mount/host-data", fs.ErrNotExist)
+    }
+
+    if err := fsys.Unmount("all"); err == nil {
+        t.Fatal("expected error when attempting to Unmount a non-mountpoint, got nil")
+    }
+
+    if err := fsys.Unmount("mount"); err != nil {
+        t.Fatal(err)
+    }
+
+    fstest.CheckFS(t, fsys, map[string]string{
+        "all":             "host",
+        "mount/host-data": "host",
+    })
+
+    if _, err := fsys.Open("mount/rickroll.mpv"); err == nil {
+        t.Fatalf("unexpected file %s: expected error %v", "mount/rickroll.mpv", fs.ErrNotExist)
+    }
+}

--- a/engine/fs/mountablefs/mountablefs_test.go
+++ b/engine/fs/mountablefs/mountablefs_test.go
@@ -106,6 +106,23 @@ func TestRemove(t *testing.T) {
         t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
     }
 
+    if err := fsys.Remove("C/D"); err == nil {
+        t.Fatalf("Remove: expected attempt to Remove a mount-point file to fail")
+    }
+
+    if err := fsys.RemoveAll("C/D"); err == nil {
+        t.Fatalf("RemoveAll: expected attempt to RemoveAll a mount-point file to fail")
+    }
+
+    if err := fsys.RemoveAll("/"); err == nil {
+        t.Fatalf("RemoveAll: expected attempt to RemoveAll a path containing a mount-point file to fail")
+    }
+
+    fstest.CheckFS(t, fsys, map[string]string{
+        // dirs are empty strings
+        "C/D/E/": "",
+    })
+
     if err := fsys.Unmount("C/D"); err != nil {
         t.Fatal(err)
     }

--- a/engine/fs/mountablefs/mountablefs_test.go
+++ b/engine/fs/mountablefs/mountablefs_test.go
@@ -9,218 +9,222 @@ import (
 )
 
 func TestMountUnmount(t *testing.T) {
-    host := memfs.New()
-    mnt := memfs.New()
+	host := memfs.New()
+	mnt := memfs.New()
 
-    fstest.WriteFS(t, host, map[string]string{
-        "all":             "host",
-        "mount/host-data": "host",
-    })
+	fstest.WriteFS(t, host, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
 
-    fstest.WriteFS(t, mnt, map[string]string{
-        "all2":         "mounted",
-        "rickroll.mpv": "mounted",
-    })
+	fstest.WriteFS(t, mnt, map[string]string{
+		"all2":         "mounted",
+		"rickroll.mpv": "mounted",
+	})
 
-    fsys := New(host)
-    if err := fsys.Mount(mnt, "mount"); err != nil {
-        t.Fatal(err)
-    }
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "mount"); err != nil {
+		t.Fatal(err)
+	}
 
-    fstest.CheckFS(t, fsys, map[string]string{
-        "all": "host",
-        "mount/all2": "mounted",
-        "mount/rickroll.mpv": "mounted",
-    })
+	fstest.CheckFS(t, fsys, map[string]string{
+		"all":                "host",
+		"mount/all2":         "mounted",
+		"mount/rickroll.mpv": "mounted",
+	})
 
-    if _, err := fsys.Open("mount/host-data"); err == nil {
-        t.Fatalf("Open: expected file %s to be masked by mount: got nil, expected %v", "mount/host-data", fs.ErrNotExist)
-    }
+	if _, err := fsys.Open("mount/host-data"); err == nil {
+		t.Fatalf("Open: expected file %s to be masked by mount: got nil, expected %v", "mount/host-data", fs.ErrNotExist)
+	}
 
-    if err := fsys.Unmount("all"); err == nil {
-        t.Fatal("Unmount: expected error when attempting to Unmount a non-mountpoint, got nil")
-    }
+	if err := fsys.Unmount("all"); err == nil {
+		t.Fatal("Unmount: expected error when attempting to Unmount a non-mountpoint, got nil")
+	}
 
-    if err := fsys.Unmount("mount"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Unmount("mount"); err != nil {
+		t.Fatal(err)
+	}
 
-    fstest.CheckFS(t, fsys, map[string]string{
-        "all":             "host",
-        "mount/host-data": "host",
-    })
+	fstest.CheckFS(t, fsys, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
 
-    if _, err := fsys.Open("mount/rickroll.mpv"); err == nil {
-        t.Fatalf("Open: unexpected file %s: expected error %v", "mount/rickroll.mpv", fs.ErrNotExist)
-    }
+	if _, err := fsys.Open("mount/rickroll.mpv"); err == nil {
+		t.Fatalf("Open: unexpected file %s: expected error %v", "mount/rickroll.mpv", fs.ErrNotExist)
+	}
 }
 
 func TestRemove(t *testing.T) {
-    host := memfs.New()
-    mnt := memfs.New()
+	host := memfs.New()
+	mnt := memfs.New()
 
-    fstest.WriteFS(t, host, map[string]string{
-        "A/B": "host",
-        "C/D/blah": "host",
-    })
+	fstest.WriteFS(t, host, map[string]string{
+		"A/B":      "host",
+		"C/D/blah": "host",
+	})
 
-    fstest.WriteFS(t, mnt, map[string]string{
-        "E/F": "mounted",
-        "G/H": "mounted",
-    })
+	fstest.WriteFS(t, mnt, map[string]string{
+		"E/F": "mounted",
+		"G/H": "mounted",
+	})
 
-    fsys := New(host)
-    if err := fsys.Mount(mnt, "C/D"); err != nil {
-        t.Fatal(err)
-    }
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "C/D"); err != nil {
+		t.Fatal(err)
+	}
 
-    fstest.CheckFS(t, fsys, map[string]string{
-        "A/B": "host",
-        "C/D/E/F": "mounted",
-        "C/D/G/H": "mounted",
-    })
+	fstest.CheckFS(t, fsys, map[string]string{
+		"A/B":     "host",
+		"C/D/E/F": "mounted",
+		"C/D/G/H": "mounted",
+	})
 
-    if err := fsys.Remove("A/B"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Remove("A/B"); err != nil {
+		t.Fatal(err)
+	}
 
-    if err := fsys.Remove("C/D/E/F"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Remove("C/D/E/F"); err != nil {
+		t.Fatal(err)
+	}
 
-    if err := fsys.RemoveAll("C/D/G"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.RemoveAll("C/D/G"); err != nil {
+		t.Fatal(err)
+	}
 
-    fstest.CheckFS(t, fsys, map[string]string{
-        // dirs are empty strings
-        "A/": "",
-        "C/D/E/": "",
-    })
+	fstest.CheckFS(t, fsys, map[string]string{
+		// dirs are empty strings
+		"A/":     "",
+		"C/D/E/": "",
+	})
 
-    if err := fsys.Remove("A/B"); err == nil {
-        t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
-    }
+	if err := fsys.Remove("A/B"); err == nil {
+		t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
+	}
 
-    if err := fsys.Remove("C/D/G"); err == nil {
-        t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
-    }
+	if err := fsys.Remove("C/D/G"); err == nil {
+		t.Fatalf("Remove: expected attempt to Remove a non-existant file to fail")
+	}
 
-    if err := fsys.Remove("C/D"); err == nil {
-        t.Fatalf("Remove: expected attempt to Remove a mount-point file to fail")
-    }
+	if err := fsys.Remove("C/D"); err == nil {
+		t.Fatalf("Remove: expected attempt to Remove a mount-point file to fail")
+	}
 
-    if err := fsys.RemoveAll("C/D"); err == nil {
-        t.Fatalf("RemoveAll: expected attempt to RemoveAll a mount-point file to fail")
-    }
+	if err := fsys.RemoveAll("C/D"); err == nil {
+		t.Fatalf("RemoveAll: expected attempt to RemoveAll a mount-point file to fail")
+	}
 
-    if err := fsys.RemoveAll("/"); err == nil {
-        t.Fatalf("RemoveAll: expected attempt to RemoveAll a path containing a mount-point file to fail")
-    }
+	if err := fsys.RemoveAll("/"); err == nil {
+		t.Fatalf("RemoveAll: expected attempt to RemoveAll a path containing a mount-point file to fail")
+	}
 
-    fstest.CheckFS(t, fsys, map[string]string{
-        // dirs are empty strings
-        "C/D/E/": "",
-    })
+	fstest.CheckFS(t, fsys, map[string]string{
+		// dirs are empty strings
+		"C/D/E/": "",
+	})
 
-    if err := fsys.Unmount("C/D"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Unmount("C/D"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRename(t *testing.T) {
-    host := memfs.New()
-    mnt := memfs.New()
+	host := memfs.New()
+	mnt := memfs.New()
 
-    fstest.WriteFS(t, host, map[string]string{
-        "all":             "host",
-        "mount/host-data": "host",
-    })
+	fstest.WriteFS(t, host, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
 
-    fstest.WriteFS(t, mnt, map[string]string{
-        "all2":         "mounted",
-        "rickroll.mpv": "mounted",
-    })
+	fstest.WriteFS(t, mnt, map[string]string{
+		"all2":         "mounted",
+		"rickroll.mpv": "mounted",
+	})
 
-    fsys := New(host)
-    if err := fsys.Mount(mnt, "mount"); err != nil {
-        t.Fatal(err)
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "mount"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Rename("all", "none"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Rename("mount/all2", "mount/none2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Rename("mount/rickroll.mpv", "rickroll.mpv"); err == nil {
+		t.Fatalf("Rename: expected error when attempting to rename across filesystems")
+	}
+
+    if err := fsys.Rename("mount", "not-a-mount"); err == nil {
+        t.Fatalf("Rename: expected error when attempting to rename a mountpoint")
     }
 
-    if err := fsys.Rename("all", "none"); err != nil {
-        t.Fatal(err)
-    }
-    
-    if err := fsys.Rename("mount/all2", "mount/none2"); err != nil {
-        t.Fatal(err)
-    }
+	fstest.CheckFS(t, fsys, map[string]string{
+		"none":               "host",
+		"mount/none2":        "mounted",
+		"mount/rickroll.mpv": "mounted",
+	})
 
-    if err := fsys.Rename("mount/rickroll.mpv", "rickroll.mpv"); err == nil {
-        t.Fatalf("Rename: expected error when attempting to rename across filesystems")
-    }
-
-    fstest.CheckFS(t, fsys, map[string]string{
-        "none": "host",
-        "mount/none2": "mounted",
-        "mount/rickroll.mpv": "mounted",
-    })
-
-    if err := fsys.Unmount("mount"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Unmount("mount"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMkdir(t *testing.T) {
-    host := memfs.New()
-    mnt := memfs.New()
+	host := memfs.New()
+	mnt := memfs.New()
 
-    fstest.WriteFS(t, host, map[string]string{
-        "all":             "host",
-        "mount/host-data": "host",
-    })
+	fstest.WriteFS(t, host, map[string]string{
+		"all":             "host",
+		"mount/host-data": "host",
+	})
 
-    fstest.WriteFS(t, mnt, map[string]string{
-        "all2":         "mounted",
-        "rickroll.mpv": "mounted",
-    })
+	fstest.WriteFS(t, mnt, map[string]string{
+		"all2":         "mounted",
+		"rickroll.mpv": "mounted",
+	})
 
-    fsys := New(host)
-    if err := fsys.Mount(mnt, "mount"); err != nil {
-        t.Fatal(err)
-    }
+	fsys := New(host)
+	if err := fsys.Mount(mnt, "mount"); err != nil {
+		t.Fatal(err)
+	}
 
-    if err := fsys.Mkdir("all/new-host-dir", 0755); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Mkdir("all/new-host-dir", 0755); err != nil {
+		t.Fatal(err)
+	}
 
-    if err := fsys.Mkdir("mount/secret_tunnel", 0755); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Mkdir("mount/secret_tunnel", 0755); err != nil {
+		t.Fatal(err)
+	}
 
-    // TODO: memfs has incorrect behavior for creating and checking parents, so until
-    // it's fixed I'm leaving these commented. They're really testing the underlying 
-    // filesystem implementation anyway.
-    // if err := fsys.Mkdir("mount/rickroll.mpv/nope", 0755); err == nil {
-    //     t.Fatalf("Mkdir: expected error when attempting to make a directory under a file")
-    // }
+	// TODO: memfs has incorrect behavior for creating and checking parents, so until
+	// it's fixed I'm leaving these commented. They're really testing the underlying
+	// filesystem implementation anyway.
+	// if err := fsys.Mkdir("mount/rickroll.mpv/nope", 0755); err == nil {
+	//     t.Fatalf("Mkdir: expected error when attempting to make a directory under a file")
+	// }
 
-    // if err := fsys.Mkdir("mount/hello/goodbye", 0755); err == nil {
-    //     t.Fatalf("Mkdir: expected error when attempting to make a directory with missing parents")
-    // }
+	// if err := fsys.Mkdir("mount/hello/goodbye", 0755); err == nil {
+	//     t.Fatalf("Mkdir: expected error when attempting to make a directory with missing parents")
+	// }
 
-    if err := fsys.MkdirAll("mount/secret_tunnel/super_secret/deadend", 0755); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.MkdirAll("mount/secret_tunnel/super_secret/deadend", 0755); err != nil {
+		t.Fatal(err)
+	}
 
-    fstest.CheckFS(t, fsys, map[string]string{
-        // dirs are empty strings
-        "all/new-host-dir/": "",
-        "mount/all2": "mounted",
-        "mount/rickroll.mpv": "mounted",
-        "mount/secret_tunnel/super_secret/deadend/": "",
-    })
+	fstest.CheckFS(t, fsys, map[string]string{
+		// dirs are empty strings
+		"all/new-host-dir/":  "",
+		"mount/all2":         "mounted",
+		"mount/rickroll.mpv": "mounted",
+		"mount/secret_tunnel/super_secret/deadend/": "",
+	})
 
-    if err := fsys.Unmount("mount"); err != nil {
-        t.Fatal(err)
-    }
+	if err := fsys.Unmount("mount"); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/engine/fs/mutablefs.go
+++ b/engine/fs/mutablefs.go
@@ -8,7 +8,7 @@ type MutableFS interface {
 	Chmod(name string, mode FileMode) error
 	Chown(name string, uid, gid int) error
 	Chtimes(name string, atime time.Time, mtime time.Time) error
-	Create(name string) (File error)
+	Create(name string) (File, error)
 	Mkdir(name string, perm FileMode) error
 	MkdirAll(path string, perm FileMode) error
 	OpenFile(name string, flag int, perm FileMode) (File, error)


### PR DESCRIPTION
This PR implements `MountableFS`, which allows the user to mount filesystems as directories. `MountableFS` implements the `MutableFS` interface and includes `Mount/Unmount` operations. Tests are included as well, alongside some small bug fixes.

I also encountered some issues with the `MemFS` implementation. Namely that functions will attempt to create parent directories whenever possible, even though it's against the spec (e.g. [Mkdir](https://pkg.go.dev/os#Mkdir)). I can open a follow up issue to address this.
