### PR TITLE
add build tags to enable building on linux

### DIFF
--- a/engine/daemon/daemon_other.go
+++ b/engine/daemon/daemon_other.go
@@ -1,3 +1,5 @@
+//go:build !linux
+
 package daemon
 
 import (


### PR DESCRIPTION
daemon_other contains a declaration that conflicts with daemon_linux. Use the build tags to only build this on non-linux systems.