### PR TITLE
[Linux] Call dlopen and dlclose in the same thread

### DIFF
--- a/desktop/run_linux.go
+++ b/desktop/run_linux.go
@@ -6,14 +6,12 @@ import (
 	"tractor.dev/toolkit-go/desktop/linux"
 )
 
-func init() {
-	linux.LoadLibraries()
-	linux.SetAllCFuncs()
-	linux.OS_Init()
-}
-
 func start() {
 	for isRunning.Load() {
+		linux.LoadLibraries()
+		linux.SetAllCFuncs()
+		linux.OS_Init()
+
 		linux.PollEvents()
 
 		select {
@@ -26,6 +24,8 @@ func start() {
 }
 
 func stop() {
-	linux.UnloadLibraries()
+	dispatch(func() {
+		linux.UnloadLibraries()
+	}, false)
 	isRunning.Store(false)
 }

--- a/desktop/window/window_linux.go
+++ b/desktop/window/window_linux.go
@@ -228,8 +228,6 @@ func findWindow(win linux.Window) *Window {
 }
 
 func init() {
-	linux.OS_Init()
-
 	linux.SetGlobalEventCallback(func(it linux.Event) {
 
 		if win := findWindow(it.Window); win != nil {


### PR DESCRIPTION
Purego Dlopen and Dlclose are just wrappers for dlopen(3) and dlclose(3) which are not thread safe. This commit makes sure that the libraries are opened and closed in the same thread, instead of init() in the module initializaiton.

This fixes the SIGABRT crash on exit.

Might be related to progrium/env86#5