### PR TITLE
[Linux] Do not use Visible property, use Hidden instead

### DIFF
--- a/desktop/window/window_linux.go
+++ b/desktop/window/window_linux.go
@@ -108,7 +108,7 @@ func (w *Window) Load() {
 		webview.AddScript(w.Options.Script)
 	}
 
-	if w.Options.Visible {
+	if !w.Options.Hidden {
 		w.win.Show()
 	}
 


### PR DESCRIPTION
- Visible is deprecated in favor of Hidden, windows should show if it's not hidden.