### PR TITLE
[Linux] Move init function out of dispatch loop

### DIFF
--- a/desktop/run_linux.go
+++ b/desktop/run_linux.go
@@ -7,13 +7,12 @@ import (
 )
 
 func start() {
+	linux.LoadLibraries()
+	linux.SetAllCFuncs()
+	linux.OS_Init()
+
 	for isRunning.Load() {
-		linux.LoadLibraries()
-		linux.SetAllCFuncs()
-		linux.OS_Init()
-
 		linux.PollEvents()
-
 		select {
 		case fn := <-dispatchQueue:
 			fn()


### PR DESCRIPTION
- OS_Init is being called two times, causing types to register for the second time which throw errors. Other init functions are also not safe to call againg. Move all of them out of the loop.

This fixes `GLib` critical errors on Ubuntu, where it would report existing types being registered again and a bunch of other assertion fails.