### PR TITLE
Exit dispatch loop right after UnloadLibraries

### DIFF
--- a/desktop/run_linux.go
+++ b/desktop/run_linux.go
@@ -25,6 +25,6 @@ func start() {
 func stop() {
 	dispatch(func() {
 		linux.UnloadLibraries()
+		isRunning.Store(false)
 	}, false)
-	isRunning.Store(false)
 }


### PR DESCRIPTION
Fix the problem where dispatch loop would run one more time after UnloadLibraries was called in stop(), ultimately calling `gtk_main_iteration_do` with an invalid library pointer.