### PR TITLE
Use 'Hidden' on windows instead of 'Visible'

### DIFF
--- a/desktop/window/window_windows.go
+++ b/desktop/window/window_windows.go
@@ -349,7 +349,7 @@ func (w *Window) Load() {
 	}
 
 	// Finally, present the window and webview.
-	if w.Options.Visible {
+	if !w.Options.Hidden {
 		w.SetVisible(true)
 	}
 


### PR DESCRIPTION
- 'Visible' is deprecated, show the window if it's not hidden explicitly.